### PR TITLE
꽃 좋아요 관리 페이지 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'source.unsplash.com',
+      },
+    ],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/public/icons/trash-can.svg
+++ b/public/icons/trash-can.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="6" y="7" width="12" height="13" stroke-width="1.5"/>
+<path d="M4 7L20 7" stroke-width="1.5"/>
+<path d="M8 4L16 4" stroke-width="1.5"/>
+<path d="M10 11L10 16" stroke-width="1.5"/>
+<path d="M14 11L14 16" stroke-width="1.5"/>
+</svg>

--- a/public/icons/trash.svg
+++ b/public/icons/trash.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="6" y="7" width="12" height="13" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M4 7L20 7" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M8 4L16 4" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M10 11L10 16" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M14 11L14 16" stroke="#BCBCBC" stroke-width="1.5"/>
+</svg>

--- a/public/icons/trash.svg
+++ b/public/icons/trash.svg
@@ -1,7 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="6" y="7" width="12" height="13" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M4 7L20 7" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M8 4L16 4" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M10 11L10 16" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M14 11L14 16" stroke="#BCBCBC" stroke-width="1.5"/>
-</svg>

--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -22,4 +22,10 @@
 </symbol><symbol id="search" viewBox="0 0 24 24">
 <path d="M17 17L22 22" stroke="white" stroke-width="1.5"/>
 <path d="M11.5 3L17.5104 5.48959L20 11.5L17.5104 17.5104L11.5 20L5.48959 17.5104L3 11.5L5.48959 5.48959L11.5 3Z" stroke="white" stroke-width="1.5"/>
+</symbol><symbol id="trash-can" viewBox="0 0 24 24">
+<rect x="6" y="7" width="12" height="13" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M4 7L20 7" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M8 4L16 4" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M10 11L10 16" stroke="#BCBCBC" stroke-width="1.5"/>
+<path d="M14 11L14 16" stroke="#BCBCBC" stroke-width="1.5"/>
 </symbol></svg>

--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -23,9 +23,9 @@
 <path d="M17 17L22 22" stroke="white" stroke-width="1.5"/>
 <path d="M11.5 3L17.5104 5.48959L20 11.5L17.5104 17.5104L11.5 20L5.48959 17.5104L3 11.5L5.48959 5.48959L11.5 3Z" stroke="white" stroke-width="1.5"/>
 </symbol><symbol id="trash-can" viewBox="0 0 24 24">
-<rect x="6" y="7" width="12" height="13" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M4 7L20 7" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M8 4L16 4" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M10 11L10 16" stroke="#BCBCBC" stroke-width="1.5"/>
-<path d="M14 11L14 16" stroke="#BCBCBC" stroke-width="1.5"/>
+<rect x="6" y="7" width="12" height="13" stroke-width="1.5"/>
+<path d="M4 7L20 7" stroke-width="1.5"/>
+<path d="M8 4L16 4" stroke-width="1.5"/>
+<path d="M10 11L10 16" stroke-width="1.5"/>
+<path d="M14 11L14 16" stroke-width="1.5"/>
 </symbol></svg>

--- a/src/api/flower-like/index.ts
+++ b/src/api/flower-like/index.ts
@@ -1,0 +1,2 @@
+export * from './useDeleteFlowerLikes';
+export * from './useGetFlowerLikes';

--- a/src/api/flower-like/useDeleteFlowerLikes.ts
+++ b/src/api/flower-like/useDeleteFlowerLikes.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { authHttp } from '../core/axios';
+import { useGetFlowerLikes } from './useGetFlowerLikes';
+
+export const useDeleteFlowerLikes = (flowerIds: number[]) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      authHttp.delete('/flower-like/flower', {
+        data: {
+          flowerIds,
+        },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: useGetFlowerLikes.queryKey });
+    },
+  });
+};

--- a/src/api/flower-like/useGetFlowerLikes.ts
+++ b/src/api/flower-like/useGetFlowerLikes.ts
@@ -3,32 +3,13 @@ import { useSuspenseQuery } from '@suspensive/react-query';
 import { authHttp } from '../core/axios';
 import { RequestSuccess } from '../core/types';
 
-const imageUrl = 'https://source.unsplash.com/random/300×300';
-
 export const useGetFlowerLikes = () => {
   return useSuspenseQuery({
     queryKey: useGetFlowerLikes.queryKey,
     queryFn: useGetFlowerLikes.queryFn,
     select: (response) => {
       const { data } = response.data;
-      // return data;
-      return {
-        totalCount: 2,
-        flowers: [
-          {
-            flowerId: 1,
-            koreanName: '물망초',
-            englishName: 'FORGET ME NOT',
-            imageUrl,
-          },
-          {
-            flowerId: 2,
-            koreanName: '안개꽃',
-            englishName: 'COMMON GYPSOPHILA',
-            imageUrl,
-          },
-        ],
-      };
+      return data;
     },
   });
 };

--- a/src/api/flower-like/useGetFlowerLikes.ts
+++ b/src/api/flower-like/useGetFlowerLikes.ts
@@ -1,0 +1,47 @@
+import { useSuspenseQuery } from '@suspensive/react-query';
+
+import { authHttp } from '../core/axios';
+import { RequestSuccess } from '../core/types';
+
+const imageUrl = 'https://source.unsplash.com/random/300×300';
+
+export const useGetFlowerLikes = () => {
+  return useSuspenseQuery({
+    queryKey: useGetFlowerLikes.queryKey,
+    queryFn: useGetFlowerLikes.queryFn,
+    select: (response) => {
+      const { data } = response.data;
+      // return data;
+      return {
+        totalCount: 2,
+        flowers: [
+          {
+            flowerId: 1,
+            koreanName: '물망초',
+            englishName: 'FORGET ME NOT',
+            imageUrl,
+          },
+          {
+            flowerId: 2,
+            koreanName: '안개꽃',
+            englishName: 'COMMON GYPSOPHILA',
+            imageUrl,
+          },
+        ],
+      };
+    },
+  });
+};
+
+interface Response {
+  totalCount: number;
+  flowers: {
+    flowerId: number;
+    koreanName: string;
+    englishName: string;
+    imageUrl: string;
+  }[];
+}
+useGetFlowerLikes.queryKey = ['flower-likes'] as const;
+useGetFlowerLikes.queryFn = () =>
+  authHttp.get<RequestSuccess<Response>>('/flower-like/flower');

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -51,7 +51,7 @@ const Sidebar = ({ isOpen, onClose }: Props) => {
               <span className='text-16-light-24 text-white'>LIKES</span>
               <Link
                 className='flex items-center gap-2 text-14-light-24 text-green-100'
-                href='/'
+                href='/likes'
                 onClick={() => onClose()}
               >
                 SEE ALL

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,5 +4,7 @@
 
 html,
 body {
+  height: 100%;
+  overflow: auto;
   font-size: 62.5%;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
       <link as='image' href='/sprite.svg' rel='preload' type='image/svg+xml' />
       <body className={`${lemonMilk.variable} ${pretendard.variable}`}>
         <QueryClientProvider>
-          <main className='relative mx-auto min-h-[100vh] max-w-[44rem] bg-green-400 font-pretendard shadow-lg'>
+          <main className='relative mx-auto h-full min-h-full max-w-[44rem] bg-green-400 font-pretendard shadow-lg'>
             <OverlayProvider>{children}</OverlayProvider>
           </main>
         </QueryClientProvider>

--- a/src/app/likes/components/LikesList.tsx
+++ b/src/app/likes/components/LikesList.tsx
@@ -1,0 +1,73 @@
+import clsx from 'clsx';
+
+import { useGetFlowerLikes } from '@/api/flower-like';
+import { Photo } from '@/common/components/photo';
+import { SvgIcon } from '@/common/components/svg-icon';
+
+interface LikesListProps {
+  editMode: boolean;
+  onSelect: (flowerId: number) => void;
+  isSelected: (flowerId: number) => boolean;
+}
+
+const LikesList = ({ editMode, onSelect, isSelected }: LikesListProps) => {
+  const flowerLikes = useGetFlowerLikes();
+
+  return (
+    <div className='grow p-20 text-white'>
+      {flowerLikes.data.flowers.length === 0 ? (
+        <p className='flex h-full items-center justify-center text-16-light-24 text-grey'>
+          아직 찜한 꽃이 없어요!
+        </p>
+      ) : (
+        <>
+          {!editMode && (
+            <div className='mb-12 text-14-light-24'>
+              총 {flowerLikes.data.totalCount}건
+            </div>
+          )}
+          <ul className='grid grid-cols-2 gap-20'>
+            {flowerLikes.data.flowers.map((flower) => {
+              return (
+                <li data-item-id={flower.flowerId} key={flower.flowerId}>
+                  <button
+                    disabled={!editMode}
+                    onClick={() => onSelect(flower.flowerId)}
+                  >
+                    <div className='relative'>
+                      <Photo
+                        alt={flower.koreanName}
+                        height='98'
+                        src={flower.imageUrl}
+                        width='158'
+                      />
+                      <div className='absolute bottom-8 left-8 flex flex-col text-left'>
+                        <span className='text-14-regular-24'>
+                          {flower.koreanName}
+                        </span>
+                        <span className='font-lemon-milk text-10-regular-12'>
+                          {flower.englishName}
+                        </span>
+                      </div>
+                      <div
+                        className={clsx([
+                          isSelected(flower.flowerId)
+                            ? 'absolute inset-0 flex items-center justify-center bg-black/70'
+                            : 'hidden',
+                        ])}
+                      >
+                        <SvgIcon height='24' id='done' role='img' width='24' />
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default LikesList;

--- a/src/app/likes/components/index.ts
+++ b/src/app/likes/components/index.ts
@@ -1,0 +1,1 @@
+export { default as LikesList } from './LikesList';

--- a/src/app/likes/hooks/index.ts
+++ b/src/app/likes/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useSelectItem';
+export * from './useToggleContext';

--- a/src/app/likes/hooks/useSelectItem.ts
+++ b/src/app/likes/hooks/useSelectItem.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+
+const mapToArray = (arg: Map<unknown, unknown>) => {
+  return Array.from(arg.keys());
+};
+
+export const useSelectItem = () => {
+  const [items, setItems] = useState<Map<number, number>>(new Map());
+
+  const selectItem = useCallback((flowerId: number) => {
+    setItems((prevItems) => {
+      const clone = new Map(prevItems);
+      if (clone.has(flowerId)) clone.delete(flowerId);
+      else clone.set(flowerId, flowerId);
+      return clone;
+    });
+  }, []);
+
+  const clearItems = useCallback(() => {
+    setItems(new Map());
+  }, []);
+
+  const isSelected = useCallback(
+    (flowerId: number) => items.has(flowerId),
+    [items]
+  );
+
+  return {
+    items: mapToArray(items) as number[],
+    count: items.size,
+    isEmpty: items.size === 0,
+    selectItem,
+    clearItems,
+    isSelected,
+  } as const;
+};

--- a/src/app/likes/layout.tsx
+++ b/src/app/likes/layout.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+export default function LikesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <section className='flex h-full min-h-full flex-col'>{children}</section>
+  );
+}

--- a/src/app/likes/page.tsx
+++ b/src/app/likes/page.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { QueryAsyncBoundary } from '@suspensive/react-query';
+import clsx from 'clsx';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { useDeleteFlowerLikes, useGetFlowerLikes } from '@/api/flower-like';
+import { Photo } from '@/common/components/photo';
+import { SvgIcon } from '@/common/components/svg-icon';
+import { useToggle } from '@/common/hooks';
+
+const mapToArray = (arg: Map<unknown, unknown>) => {
+  return Array.from(arg.keys());
+};
+
+export default function LikesPage() {
+  const [editMode, handleEditMode] = useToggle();
+  const [selectedItems, setSelectedItems] = useState<Map<number, number>>(
+    new Map()
+  );
+  const router = useRouter();
+
+  const deleteFlowerLikes = useDeleteFlowerLikes(
+    mapToArray(selectedItems) as number[]
+  );
+  useEffect(() => {
+    setSelectedItems(new Map());
+  }, [editMode]);
+
+  const selectItem = (flowerId: number) => {
+    setSelectedItems((prevItems) => {
+      const clone = new Map(prevItems);
+      if (clone.has(flowerId)) clone.delete(flowerId);
+      else clone.set(flowerId, flowerId);
+      return clone;
+    });
+  };
+
+  const isSelected = (flowerId: number) => selectedItems.has(flowerId);
+
+  return (
+    <>
+      <header className='flex justify-between bg-green-200 p-16'>
+        <div className='flex gap-12'>
+          {editMode ? (
+            <div className='text-16-light-24 text-white'>
+              {selectedItems.size}개 선택 됨
+            </div>
+          ) : (
+            <>
+              <Link href='/'>
+                <SvgIcon height='24' id='left-arrow' width='24' />
+              </Link>
+              <div className='font-lemon-milk text-16-light-24 text-white'>
+                LIKES
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className='flex gap-12'>
+          {editMode && (
+            <button
+              disabled={selectedItems.size === 0}
+              onClick={() => {
+                deleteFlowerLikes.mutate();
+              }}
+            >
+              {selectedItems.size === 0 ? (
+                <SvgIcon
+                  height='24'
+                  id='trash-can'
+                  stroke='#bcbcbc'
+                  width='24'
+                />
+              ) : (
+                <SvgIcon
+                  height='24'
+                  id='trash-can'
+                  stroke='#ffcbf1'
+                  width='24'
+                />
+              )}
+            </button>
+          )}
+          <button className='' onClick={handleEditMode}>
+            <SvgIcon height='24' id='pencil' width='24' />
+          </button>
+        </div>
+      </header>
+
+      <QueryAsyncBoundary
+        rejectedFallback={(boundary) => (
+          <button onClick={boundary.reset}>Try again</button>
+        )}
+        onError={() => router.push('/signin')}
+      >
+        <LikesList
+          editMode={editMode}
+          isSelected={isSelected}
+          onSelect={selectItem}
+        />
+      </QueryAsyncBoundary>
+    </>
+  );
+}
+
+interface LikesListProps {
+  editMode: boolean;
+  onSelect: (flowerId: number) => void;
+  isSelected: (flowerId: number) => boolean;
+}
+
+const LikesList = ({ editMode, onSelect, isSelected }: LikesListProps) => {
+  const flowerLikes = useGetFlowerLikes();
+
+  return (
+    <div className='grow p-20 text-white'>
+      {flowerLikes.data.flowers.length === 0 ? (
+        <p className='flex h-full items-center justify-center text-16-light-24 text-grey'>
+          아직 찜한 꽃이 없어요!
+        </p>
+      ) : (
+        <>
+          {!editMode && (
+            <div className='mb-12 text-14-light-24'>
+              총 {flowerLikes.data.totalCount}건
+            </div>
+          )}
+          <ul className='grid grid-cols-2 gap-20'>
+            {flowerLikes.data.flowers.map((flower) => {
+              return (
+                <li data-item-id={flower.flowerId} key={flower.flowerId}>
+                  <button
+                    disabled={!editMode}
+                    onClick={() => onSelect(flower.flowerId)}
+                  >
+                    <div className='relative'>
+                      <Photo
+                        alt={flower.koreanName}
+                        height='98'
+                        src={flower.imageUrl}
+                        width='158'
+                      />
+                      <div className='absolute bottom-8 left-8 flex flex-col text-left'>
+                        <span className='text-14-regular-24'>
+                          {flower.koreanName}
+                        </span>
+                        <span className='font-lemon-milk text-10-regular-12'>
+                          {flower.englishName}
+                        </span>
+                      </div>
+                      <div
+                        className={clsx([
+                          isSelected(flower.flowerId)
+                            ? 'absolute inset-0 flex items-center justify-center bg-black/70'
+                            : 'hidden',
+                        ])}
+                      >
+                        <SvgIcon height='24' id='done' role='img' width='24' />
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/app/likes/page.tsx
+++ b/src/app/likes/page.tsx
@@ -1,44 +1,21 @@
 'use client';
 
 import { QueryAsyncBoundary } from '@suspensive/react-query';
-import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
 
-import { useDeleteFlowerLikes, useGetFlowerLikes } from '@/api/flower-like';
-import { Photo } from '@/common/components/photo';
+import { useDeleteFlowerLikes } from '@/api/flower-like';
 import { SvgIcon } from '@/common/components/svg-icon';
 import { useToggle } from '@/common/hooks';
 
-const mapToArray = (arg: Map<unknown, unknown>) => {
-  return Array.from(arg.keys());
-};
+import { LikesList } from './components';
+import { useSelectItem } from './hooks';
 
 export default function LikesPage() {
-  const [editMode, handleEditMode] = useToggle();
-  const [selectedItems, setSelectedItems] = useState<Map<number, number>>(
-    new Map()
-  );
   const router = useRouter();
-
-  const deleteFlowerLikes = useDeleteFlowerLikes(
-    mapToArray(selectedItems) as number[]
-  );
-  useEffect(() => {
-    setSelectedItems(new Map());
-  }, [editMode]);
-
-  const selectItem = (flowerId: number) => {
-    setSelectedItems((prevItems) => {
-      const clone = new Map(prevItems);
-      if (clone.has(flowerId)) clone.delete(flowerId);
-      else clone.set(flowerId, flowerId);
-      return clone;
-    });
-  };
-
-  const isSelected = (flowerId: number) => selectedItems.has(flowerId);
+  const [editMode, handleEditMode] = useToggle();
+  const select = useSelectItem();
+  const deleteFlowerLikes = useDeleteFlowerLikes(select.items);
 
   return (
     <>
@@ -46,7 +23,7 @@ export default function LikesPage() {
         <div className='flex gap-12'>
           {editMode ? (
             <div className='text-16-light-24 text-white'>
-              {selectedItems.size}개 선택 됨
+              {select.count}개 선택 됨
             </div>
           ) : (
             <>
@@ -63,12 +40,12 @@ export default function LikesPage() {
         <div className='flex gap-12'>
           {editMode && (
             <button
-              disabled={selectedItems.size === 0}
+              disabled={select.isEmpty}
               onClick={() => {
                 deleteFlowerLikes.mutate();
               }}
             >
-              {selectedItems.size === 0 ? (
+              {select.isEmpty ? (
                 <SvgIcon
                   height='24'
                   id='trash-can'
@@ -85,7 +62,12 @@ export default function LikesPage() {
               )}
             </button>
           )}
-          <button className='' onClick={handleEditMode}>
+          <button
+            onClick={() => {
+              select.clearItems();
+              handleEditMode();
+            }}
+          >
             <SvgIcon height='24' id='pencil' width='24' />
           </button>
         </div>
@@ -99,76 +81,10 @@ export default function LikesPage() {
       >
         <LikesList
           editMode={editMode}
-          isSelected={isSelected}
-          onSelect={selectItem}
+          isSelected={select.isSelected}
+          onSelect={select.selectItem}
         />
       </QueryAsyncBoundary>
     </>
   );
 }
-
-interface LikesListProps {
-  editMode: boolean;
-  onSelect: (flowerId: number) => void;
-  isSelected: (flowerId: number) => boolean;
-}
-
-const LikesList = ({ editMode, onSelect, isSelected }: LikesListProps) => {
-  const flowerLikes = useGetFlowerLikes();
-
-  return (
-    <div className='grow p-20 text-white'>
-      {flowerLikes.data.flowers.length === 0 ? (
-        <p className='flex h-full items-center justify-center text-16-light-24 text-grey'>
-          아직 찜한 꽃이 없어요!
-        </p>
-      ) : (
-        <>
-          {!editMode && (
-            <div className='mb-12 text-14-light-24'>
-              총 {flowerLikes.data.totalCount}건
-            </div>
-          )}
-          <ul className='grid grid-cols-2 gap-20'>
-            {flowerLikes.data.flowers.map((flower) => {
-              return (
-                <li data-item-id={flower.flowerId} key={flower.flowerId}>
-                  <button
-                    disabled={!editMode}
-                    onClick={() => onSelect(flower.flowerId)}
-                  >
-                    <div className='relative'>
-                      <Photo
-                        alt={flower.koreanName}
-                        height='98'
-                        src={flower.imageUrl}
-                        width='158'
-                      />
-                      <div className='absolute bottom-8 left-8 flex flex-col text-left'>
-                        <span className='text-14-regular-24'>
-                          {flower.koreanName}
-                        </span>
-                        <span className='font-lemon-milk text-10-regular-12'>
-                          {flower.englishName}
-                        </span>
-                      </div>
-                      <div
-                        className={clsx([
-                          isSelected(flower.flowerId)
-                            ? 'absolute inset-0 flex items-center justify-center bg-black/70'
-                            : 'hidden',
-                        ])}
-                      >
-                        <SvgIcon height='24' id='done' role='img' width='24' />
-                      </div>
-                    </div>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        </>
-      )}
-    </div>
-  );
-};

--- a/src/app/search/components/SearchForm.tsx
+++ b/src/app/search/components/SearchForm.tsx
@@ -13,7 +13,8 @@ import { useSearchHistory } from '../hooks';
 
 const SearchForm = () => {
   const searchHandle = useSearchHandle();
-  const flowerSearch = useGetFlowerSearch(searchHandle.value);
+  const deferredValue = useDeferredValue(searchHandle.value);
+  const flowerSearch = useGetFlowerSearch(deferredValue);
   const searchText = useSearchParams().get('q');
 
   return (
@@ -76,7 +77,6 @@ export default SearchForm;
 
 const useSearchHandle = () => {
   const [value, setValue, handleValue] = useInputState('');
-  const deferredValue = useDeferredValue(value);
   const searchHistory = useSearchHistory();
   const router = useRouter();
 
@@ -95,7 +95,7 @@ const useSearchHandle = () => {
   }, [router, setValue]);
 
   return {
-    value: deferredValue,
+    value,
     setValue,
     handleValue,
     handleSubmit,

--- a/src/app/signin/layout.tsx
+++ b/src/app/signin/layout.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 export default function SigninLayout({
   children,
@@ -7,7 +7,7 @@ export default function SigninLayout({
 }) {
   return (
     <>
-      <section className="relative flex min-h-screen flex-col justify-center bg-[url('/images/background-image.png')] px-20">
+      <section className="relative flex h-full min-h-full flex-col justify-center bg-[url('/images/background-image.png')] px-20">
         {children}
       </section>
     </>

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -24,13 +24,15 @@ export default function Signin() {
         <span className='h-px w-full flex-1 bg-white'></span>
       </section>
 
-      <button type='button' onClick={handleButtonClick}>
+      <button
+        className='mx-auto h-45 w-300'
+        type='button'
+        onClick={handleButtonClick}
+      >
         <Photo
           alt='카카오 로그인 버튼'
           className='m-auto'
-          height='45'
           src='/images/kakao-login.png'
-          width='300'
         />
       </button>
     </>

--- a/src/common/components/photo/Photo.tsx
+++ b/src/common/components/photo/Photo.tsx
@@ -1,13 +1,13 @@
-import Image from "next/image";
-import type { ComponentProps } from "react";
+import Image from 'next/image';
+import type { ComponentProps } from 'react';
 
 type Props = ComponentProps<typeof Image>;
 const base64Blur =
-  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAQAAAAnOwc2AAAAEUlEQVR42mO8/Z8BAzAOZUEAQ+ESj6kXXm0AAAAASUVORK5CYII=";
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAQAAAAnOwc2AAAAEUlEQVR42mO8/Z8BAzAOZUEAQ+ESj6kXXm0AAAAASUVORK5CYII=';
 
 const Photo = ({
-  alt = "thumbnail",
-  className = "",
+  alt = 'thumbnail',
+  className = '',
   width,
   height,
   ...rest
@@ -15,15 +15,15 @@ const Photo = ({
   return (
     <div
       className={`relative overflow-hidden [&>img]:!static ${className}`}
-      style={{ width: `${width}px`, height: `${height}px` }}
+      style={{ aspectRatio: `calc(${width} / ${height})` }}
     >
       <Image
         fill
         alt={alt}
         blurDataURL={base64Blur}
-        placeholder="blur"
-        sizes=" "
-        style={{ objectFit: "cover" }}
+        placeholder='blur'
+        sizes=' '
+        style={{ objectFit: 'cover' }}
         {...rest}
       />
     </div>

--- a/src/common/components/svg-icon/SvgIcon.tsx
+++ b/src/common/components/svg-icon/SvgIcon.tsx
@@ -1,4 +1,4 @@
-import { SVGProps } from "react";
+import { SVGProps } from 'react';
 
 interface Props extends SVGProps<SVGSVGElement> {
   /** NOTE: icon id (icons 폴더 아래에 있는 svg 파일명과 동일함) */
@@ -9,11 +9,12 @@ const SvgIcon = ({
   id,
   width = 16,
   height = 16,
-  fill = "none",
+  fill = 'none',
+  stroke,
   ...rest
 }: Props) => {
   return (
-    <svg fill={fill} height={height} width={width} {...rest}>
+    <svg fill={fill} height={height} stroke={stroke} width={width} {...rest}>
       <use href={`/sprite.svg#${id}`} />
     </svg>
   );

--- a/src/common/hooks/index.ts
+++ b/src/common/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './use-overlay';
 export * from './useInputState';
 export * from './useLocalStorage';
+export * from './useToggle';

--- a/src/common/hooks/useToggle.ts
+++ b/src/common/hooks/useToggle.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export const useToggle = (defaultValue = false) => {
+  const [value, setValue] = useState(!!defaultValue);
+
+  const toggle = useCallback(() => setValue((prev) => !prev), []);
+
+  return [value, toggle, setValue] as const;
+};

--- a/src/common/react-query/query-client.tsx
+++ b/src/common/react-query/query-client.tsx
@@ -1,14 +1,14 @@
-'use client'
+'use client';
 
-import type { DehydratedState } from "@tanstack/react-query";
+import type { DehydratedState } from '@tanstack/react-query';
 import {
   Hydrate,
   QueryClient,
   QueryClientProvider as TanStackQueryClientProvider,
-} from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import type { ReactNode } from "react";
-import { useState } from "react";
+} from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
 
 interface Props {
   hydrateState?: DehydratedState;
@@ -24,6 +24,7 @@ const QueryClientProvider = ({ hydrateState, children }: Props) => {
             retry: 0,
             useErrorBoundary: true,
             staleTime: 1000 * 5,
+            refetchOnWindowFocus: false,
           },
         },
       })
@@ -32,7 +33,7 @@ const QueryClientProvider = ({ hydrateState, children }: Props) => {
   return (
     <TanStackQueryClientProvider client={queryClient}>
       <Hydrate state={hydrateState}>{children}</Hydrate>
-      <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
+      <ReactQueryDevtools initialIsOpen={false} position='bottom-right' />
     </TanStackQueryClientProvider>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,9 +42,17 @@ module.exports = {
           '2.4rem',
           { lineHeight: '32px', letterSpacing: '0em', fontWeight: '700' },
         ],
+        '10-regular-12': [
+          '1.0rem',
+          { lineHeight: '12px', letterSpacing: '0em', fontWeight: '400' },
+        ],
         '14-light-24': [
           '1.4rem',
           { lineHeight: '24px', letterSpacing: '0em', fontWeight: '300' },
+        ],
+        '14-regular-24': [
+          '1.4rem',
+          { lineHeight: '24px', letterSpacing: '0em', fontWeight: '400' },
         ],
         '24-light-32': [
           '2.4rem',


### PR DESCRIPTION
close #19 

## 작업 내용
- 인가 로직 수정: 401 에러시에만 Refresh 요청을 호출하도록 수정
- useToggle hook 구현
- 꽃 좋아요 추가/삭제 API 연동 및 좋아요 관리 페이지 디자인

## 리팩터링 필요한 부분
- [ ] likes 페이지 추상화 레벨 맞추기
  - context? 전역 상태 사용?
