### PR TITLE
feat: 검색 결과 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "make-sprite": "rm public/sprite.svg && svgstore -o public/sprite.svg public/icons/**/*.svg"
   },
   "dependencies": {
+    "@mui/base": "^5.0.0-beta.6",
     "@suspensive/react": "^1.11.1",
     "@suspensive/react-query": "^1.11.1",
     "@tanstack/react-query": "^4.29.5",

--- a/public/icons/delete.svg
+++ b/public/icons/delete.svg
@@ -1,0 +1,4 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L9 9"/>
+<path d="M9 1L1 9"/>
+</svg>

--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -1,4 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs/><symbol id="done" viewBox="0 0 24 24">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs/><symbol id="delete" viewBox="0 0 10 10">
+<path d="M1 1L9 9"/>
+<path d="M9 1L1 9"/>
+</symbol><symbol id="done" viewBox="0 0 24 24">
 <path d="M3 12.129L8.6 18L21 5" stroke="white"/>
 </symbol><symbol id="left-arrow" viewBox="0 0 24 24">
 <g id="ic_go">

--- a/src/api/flower-search/index.ts
+++ b/src/api/flower-search/index.ts
@@ -1,2 +1,3 @@
 export * from './useGetFlowerSearch';
 export * from './useGetPopularFlower';
+export * from './useSearchAutoComplete';

--- a/src/api/flower-search/useGetFlowerSearch.ts
+++ b/src/api/flower-search/useGetFlowerSearch.ts
@@ -1,22 +1,59 @@
 import { useSuspenseQuery } from '@suspensive/react-query';
 
 import { http } from '../core/axios';
-import {  RequestState } from '../core/types';
+import { RequestSuccess } from '../core/types';
+
+const imageUrl = 'https://source.unsplash.com/random/300×300';
+export type Empty = 'empty';
+export type Exist = 'exist';
 
 export const useGetFlowerSearch = (keyword: string) => {
-
   return useSuspenseQuery({
     queryKey: useGetFlowerSearch.queryKey(keyword),
     queryFn: () => useGetFlowerSearch.queryFn(keyword),
-    enabled: !!keyword,
     select: (response) => {
       const { data } = response.data;
-      return data && data.flowers.length !== 0
-        ? data.flowers.map((flower) => ({
-            flowerId: flower.flowerId,
-            koreanName: flower.koreanName,
-          }))
-        : null;
+      const { flowerTags, flowers, contentSummaryInfos } = data;
+      if (
+        flowerTags.length === 0 &&
+        flowers.length === 0 &&
+        contentSummaryInfos.length === 0
+      ) {
+        return { type: 'empty' as Empty, ...data };
+      }
+      return { type: 'exist' as Exist, ...data };
+      // return {
+      //   type: 'exist',
+      //   flowerTags: ['프로포즈', '봄'],
+      //   flowers: [
+      //     {
+      //       flowerId: 1,
+      //       koreanName: '은방울꽃',
+      //       englishName: 'LILY OF THE VALLEY',
+      //       imageUrl,
+      //     },
+      //     {
+      //       flowerId: 2,
+      //       koreanName: '은방울꽃',
+      //       englishName: 'LILY OF THE VALLEY',
+      //       imageUrl,
+      //     },
+      //   ],
+      //   contentSummaryInfos: [
+      //     {
+      //       contentId: 1,
+      //       imageUrl,
+      //       title: 'MONODSFOE',
+      //       subtitle: '은방울은방울은방울',
+      //     },
+      //     {
+      //       contentId: 2,
+      //       imageUrl,
+      //       title: 'MONODSFOE',
+      //       subtitle: '은방울은방울은방울',
+      //     },
+      //   ],
+      // };
     },
   });
 };
@@ -29,12 +66,17 @@ interface Response {
     englishName: string;
     imageUrl: string;
   }[];
-  contentSummaryInfos: { contentId: number; imageUrl: string }[];
+  contentSummaryInfos: {
+    contentId: number;
+    imageUrl: string;
+    title: string;
+    subtitle: string;
+  }[];
 }
 
 useGetFlowerSearch.queryKey = (keyword: string) =>
   ['flower-search', keyword] as const;
 useGetFlowerSearch.queryFn = (keyword: string) =>
-  http.get<RequestState<Response>>('/flower-search/flowers', {
+  http.get<RequestSuccess<Response>>('/flower-search/flowers', {
     params: { searchText: keyword },
   });

--- a/src/api/flower-search/useGetFlowerSearch.ts
+++ b/src/api/flower-search/useGetFlowerSearch.ts
@@ -3,7 +3,6 @@ import { useSuspenseQuery } from '@suspensive/react-query';
 import { http } from '../core/axios';
 import { RequestSuccess } from '../core/types';
 
-const imageUrl = 'https://source.unsplash.com/random/300×300';
 export type Empty = 'empty';
 export type Exist = 'exist';
 
@@ -22,38 +21,6 @@ export const useGetFlowerSearch = (keyword: string) => {
         return { type: 'empty' as Empty, ...data };
       }
       return { type: 'exist' as Exist, ...data };
-      // return {
-      //   type: 'exist',
-      //   flowerTags: ['프로포즈', '봄'],
-      //   flowers: [
-      //     {
-      //       flowerId: 1,
-      //       koreanName: '은방울꽃',
-      //       englishName: 'LILY OF THE VALLEY',
-      //       imageUrl,
-      //     },
-      //     {
-      //       flowerId: 2,
-      //       koreanName: '은방울꽃',
-      //       englishName: 'LILY OF THE VALLEY',
-      //       imageUrl,
-      //     },
-      //   ],
-      //   contentSummaryInfos: [
-      //     {
-      //       contentId: 1,
-      //       imageUrl,
-      //       title: 'MONODSFOE',
-      //       subtitle: '은방울은방울은방울',
-      //     },
-      //     {
-      //       contentId: 2,
-      //       imageUrl,
-      //       title: 'MONODSFOE',
-      //       subtitle: '은방울은방울은방울',
-      //     },
-      //   ],
-      // };
     },
   });
 };

--- a/src/api/flower-search/useSearchAutoComplete.ts
+++ b/src/api/flower-search/useSearchAutoComplete.ts
@@ -1,0 +1,32 @@
+import { useSuspenseQuery } from '@suspensive/react-query';
+
+import { http } from '../core/axios';
+import { RequestSuccess } from '../core/types';
+
+export const useSearchAutoComplete = (
+  keyword: string,
+  { enabled }: { enabled?: boolean } = {}
+) => {
+  return useSuspenseQuery({
+    queryKey: useSearchAutoComplete.queryKey(keyword),
+    queryFn: () => useSearchAutoComplete.queryFn(keyword),
+    enabled,
+    staleTime: Infinity,
+    select: (response) => {
+      const { data } = response.data;
+      return data.autocompletes;
+    },
+  });
+};
+
+interface Response {
+  autocompletes: string[];
+}
+
+useSearchAutoComplete.queryKey = (keyword: string) =>
+  ['flower-search', 'autocomplete', keyword] as const;
+
+useSearchAutoComplete.queryFn = (keyword: string) =>
+  http.get<RequestSuccess<Response>>('/flower-search/autocomplete', {
+    params: { searchText: keyword },
+  });

--- a/src/api/user/useGetProfile.ts
+++ b/src/api/user/useGetProfile.ts
@@ -29,7 +29,6 @@ export const useGetProfile = () => {
       return data;
     },
     onError: (error: AxiosError<RequestError>) => {
-      console.log(error.response);
       queryClient.setQueryData(useGetProfile.queryKey, error.response);
     },
   });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
       <link as='image' href='/sprite.svg' rel='preload' type='image/svg+xml' />
       <body className={`${lemonMilk.variable} ${pretendard.variable}`}>
         <QueryClientProvider>
-          <main className='relative mx-auto h-full min-h-full max-w-[44rem] bg-green-400 font-pretendard shadow-lg'>
+          <main className='relative mx-auto h-fit min-h-full max-w-[44rem] bg-green-400 font-pretendard shadow-lg'>
             <OverlayProvider>{children}</OverlayProvider>
           </main>
         </QueryClientProvider>

--- a/src/app/likes/hooks/index.ts
+++ b/src/app/likes/hooks/index.ts
@@ -1,2 +1,1 @@
 export * from './useSelectItem';
-export * from './useToggleContext';

--- a/src/app/search/@main/page.tsx
+++ b/src/app/search/@main/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Suspense } from '@suspensive/react';
+
+import { 인기검색어, 최근검색어 } from '../components';
+
+export default function SearchMainPage() {
+  return (
+    <>
+      <Suspense.CSROnly>
+        <최근검색어 />
+      </Suspense.CSROnly>
+
+      <Suspense>
+        <인기검색어 />
+      </Suspense>
+    </>
+  );
+}

--- a/src/app/search/@result/page.tsx
+++ b/src/app/search/@result/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { QueryAsyncBoundary } from '@suspensive/react-query';
+
+import { 검색결과 } from '../components';
+
+export default function SearchResultPage() {
+  return (
+    <>
+      <QueryAsyncBoundary.CSROnly
+        rejectedFallback={(boundary) => (
+          <button onClick={boundary.reset}>Try again</button>
+        )}
+      >
+        <검색결과 />
+      </QueryAsyncBoundary.CSROnly>
+    </>
+  );
+}

--- a/src/app/search/components/Chip.tsx
+++ b/src/app/search/components/Chip.tsx
@@ -1,19 +1,21 @@
 import clsx from 'clsx';
-import { ComponentProps } from 'react';
+import { ComponentProps, ReactNode } from 'react';
 
 interface ChipProps extends ComponentProps<'button'> {
   label: string;
+  leftComponent?: ReactNode;
 }
-const Chip = ({ label, className, ...rest }: ChipProps) => {
+const Chip = ({ label, className, leftComponent, ...rest }: ChipProps) => {
   return (
     <button
       {...rest}
       className={clsx(
-        'rounded-full border border-yellow px-12 py-2 text-[1.2rem] font-light leading-[2.4rem] text-yellow',
+        'flex items-center gap-8 rounded-full border px-12 py-2 text-[1.2rem] font-light leading-[2.4rem]',
         className
       )}
     >
       {label}
+      {leftComponent}
     </button>
   );
 };

--- a/src/app/search/components/Header.tsx
+++ b/src/app/search/components/Header.tsx
@@ -10,7 +10,7 @@ const Header = () => {
   const searchParams = useSearchParams();
   const searchText = searchParams.get('q');
   return (
-    <header className={clsx('p-16', [!!searchText && 'bg-green-200'])}>
+    <header className={clsx('flex p-16', [!!searchText && 'bg-green-200'])}>
       <Link href='/search'>
         <SvgIcon height='24' id='left-arrow' width='24' />
       </Link>

--- a/src/app/search/components/SearchForm.tsx
+++ b/src/app/search/components/SearchForm.tsx
@@ -1,70 +1,99 @@
 'use client';
 
+import { useAutocomplete } from '@mui/base';
 import clsx from 'clsx';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { FormEventHandler, useCallback, useDeferredValue } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useDeferredValue } from 'react';
 
-import { useGetFlowerSearch } from '@/api/flower-search';
+import { useSearchAutoComplete } from '@/api/flower-search';
 import { Input } from '@/common/components/input';
 import { SvgIcon } from '@/common/components/svg-icon';
-import { useInputState } from '@/common/hooks';
 
-import { useSearchHistory } from '../hooks';
+import { useSearchHandle } from '../hooks';
 
 const SearchForm = () => {
   const searchHandle = useSearchHandle();
   const deferredValue = useDeferredValue(searchHandle.value);
-  const flowerSearch = useGetFlowerSearch(deferredValue);
-  const searchText = useSearchParams().get('q');
+  const searchComplete = useSearchAutoComplete(deferredValue, {
+    enabled: !!deferredValue,
+  });
+  const {
+    getRootProps,
+    getInputProps,
+    getListboxProps,
+    getOptionProps,
+    groupedOptions,
+  } = useAutocomplete({
+    id: 'blossom-auto-complete',
+    options: searchComplete.data || [],
+    value: searchHandle.value,
+    onChange: (event, newValue) => {
+      searchHandle.setValue(newValue as string);
+      searchHandle.handleSearch(newValue as string);
+    },
+  });
+  const hasSearchText = useSearchParams().get('q');
 
   return (
-    <section>
-      <form onSubmit={searchHandle.handleSubmit}>
-        <Input
-          className='bg-transparent text-24-regular-32 placeholder:text-24-light-32 placeholder:text-grey'
-          placeholder='검색어를 입력하세요'
-          value={searchHandle.value}
-          rightComponent={
-            searchText ? (
-              <button type='button' onClick={searchHandle.handleDeleteValue}>
-                <SvgIcon
-                  aria-labelledby='검색어 지우기'
-                  height='24'
-                  id='menu-out'
-                  role='img'
-                  width='24'
-                />
-              </button>
-            ) : (
-              <button type='submit' onClick={searchHandle.handleSubmit}>
-                <SvgIcon
-                  aria-labelledby='꽃 검색하기'
-                  height='24'
-                  id='search'
-                  role='img'
-                  width='24'
-                />
-              </button>
-            )
-          }
-          wrapperClassName={clsx(
-            'border-b border-b-white px-16 py-12 text-24-semibold-24 text-white',
-            [!!searchText && 'border-none bg-green-200']
-          )}
-          onChange={searchHandle.handleValue}
-        />
-      </form>
-      {flowerSearch.data && (
-        <ul className='absolute flex h-full w-full flex-col bg-green-400 py-16 text-[2rem] font-normal leading-[3.2rem] text-green-100'>
-          {flowerSearch.data.map((flower) => (
-            <li className='hover:bg-green-300' key={flower.flowerId}>
-              <button
-                className='h-full w-full px-16 py-8 text-left'
-                type='submit'
-                onClick={searchHandle.handleSubmit}
-              >
-                {flower.koreanName}
-              </button>
+    <section className='sticky top-0'>
+      <div {...getRootProps()}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            searchHandle.handleSearch(searchHandle.value);
+          }}
+        >
+          <Input
+            {...getInputProps()}
+            className='bg-transparent text-24 font-normal placeholder:font-light placeholder:text-grey'
+            placeholder='검색어를 입력하세요'
+            value={searchHandle.value}
+            rightComponent={
+              hasSearchText ? (
+                <button type='button' onClick={() => searchHandle.setValue('')}>
+                  <SvgIcon
+                    aria-labelledby='검색어 지우기'
+                    height='24'
+                    id='menu-out'
+                    role='img'
+                    width='24'
+                  />
+                </button>
+              ) : (
+                <button
+                  type='submit'
+                  onClick={() => searchHandle.handleSearch(searchHandle.value)}
+                >
+                  <SvgIcon
+                    aria-labelledby='꽃 검색하기'
+                    height='24'
+                    id='search'
+                    role='img'
+                    width='24'
+                  />
+                </button>
+              )
+            }
+            wrapperClassName={clsx(
+              'border-b border-b-white px-16 py-12 text-24 font-semibold leading-24 text-white',
+              [hasSearchText && 'border-none bg-green-200']
+            )}
+            onChange={searchHandle.handleChange}
+          />
+        </form>
+      </div>
+      {groupedOptions.length > 0 && (
+        <ul
+          {...getListboxProps()}
+          className='absolute w-full bg-green-400 py-16 text-20 font-normal leading-32 text-green-100'
+        >
+          {(groupedOptions as string[]).map((option, index) => (
+            <li
+              className='cursor-pointer px-16 py-8 text-left hover:bg-green-300 aria-selected:bg-green-300 [&.Mui-focusVisible]:bg-green-300 [&.Mui-focused]:bg-green-300'
+              key={index}
+              {...getOptionProps({ option, index })}
+            >
+              {option}
             </li>
           ))}
         </ul>
@@ -74,31 +103,3 @@ const SearchForm = () => {
 };
 
 export default SearchForm;
-
-const useSearchHandle = () => {
-  const [value, setValue, handleValue] = useInputState('');
-  const searchHistory = useSearchHistory();
-  const router = useRouter();
-
-  const handleSubmit: FormEventHandler<HTMLElement> = useCallback(
-    (e) => {
-      e.preventDefault();
-      router.push(`/search?q=${value}`);
-      searchHistory.add(value);
-    },
-    [value, router, searchHistory]
-  );
-
-  const handleDeleteValue = useCallback(() => {
-    setValue('');
-    router.push('/search');
-  }, [router, setValue]);
-
-  return {
-    value,
-    setValue,
-    handleValue,
-    handleSubmit,
-    handleDeleteValue,
-  } as const;
-};

--- a/src/app/search/components/index.ts
+++ b/src/app/search/components/index.ts
@@ -1,5 +1,6 @@
 export { default as Chip } from './Chip';
 export { default as Header } from './Header';
 export { default as SearchForm } from './SearchForm';
+export { default as 검색결과 } from './검색결과';
 export { default as 인기검색어 } from './인기검색어';
 export { default as 최근검색어 } from './최근검색어';

--- a/src/app/search/components/검색결과.tsx
+++ b/src/app/search/components/검색결과.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { useGetFlowerSearch } from '@/api/flower-search';
+import { Photo } from '@/common/components/photo';
+
+import Chip from './Chip';
+
+const 검색결과 = () => {
+  const searchParams = useSearchParams();
+  const searchText = searchParams.get('q');
+  const flowerSearch = useGetFlowerSearch(searchText as string);
+  const router = useRouter();
+
+  if (flowerSearch.data.type === 'empty') {
+    return (
+      <section className='flex w-full grow items-center justify-center p-20 text-24 font-medium leading-24 text-grey'>
+        검색.. 결과,, 결과가 없어요.,..? 아놔
+      </section>
+    );
+  }
+  const {
+    data: { flowerTags, flowers, contentSummaryInfos },
+  } = flowerSearch;
+  return (
+    <>
+      <section className='p-20'>
+        <ul className='flex flex-wrap gap-12 text-12 font-light leading-24 text-green-100'>
+          {flowerTags.map((flower, index) => (
+            <li key={index}>
+              <Chip
+                className='border-yellow text-yellow'
+                key={index}
+                label={`#${flower}`}
+                onClick={() => router.push(`/search?q=${flower}`)}
+              />
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className='p-20'>
+        <h3 className='mb-16 border-b-2 border-white font-lemon-milk text-16 font-normal leading-24 text-white'>
+          FLOWERS
+        </h3>
+        <ul className='grid grid-cols-2 gap-20'>
+          {flowers.map((flower) => (
+            <li data-item-id={flower.flowerId} key={flower.flowerId}>
+              <Link href={`/flowers/${flower.flowerId}`}>
+                <div className='relative'>
+                  <Photo
+                    alt={flower.koreanName}
+                    height='98'
+                    src={flower.imageUrl}
+                    width='158'
+                  />
+                  <div className='absolute bottom-8 left-8 flex flex-col text-left'>
+                    <span className='text-14-regular-24'>
+                      {flower.koreanName}
+                    </span>
+                    <span className='font-lemon-milk text-10-regular-12'>
+                      {flower.englishName}
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className='p-20'>
+        <h3 className='mb-16 border-b-2 border-white font-lemon-milk text-16 font-normal leading-24 text-white'>
+          CONTENTS
+        </h3>
+        <ul className='flex flex-col gap-20'>
+          {contentSummaryInfos.map((content) => (
+            <li data-item-id={content.contentId} key={content.contentId}>
+              <Link href={`/contents/${content.contentId}`}>
+                <div className='relative'>
+                  <Photo
+                    alt='temp'
+                    height='98'
+                    src={content.imageUrl}
+                    width='158'
+                  />
+                  <div className='absolute bottom-8 left-8 flex flex-col gap-4 p-12 text-left'>
+                    <span className='text-16 font-medium leading-24'>
+                      {content.subtitle}
+                    </span>
+                    <span className='font-lemon-milk text-30 font-medium leading-32'>
+                      {content.title}
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </>
+  );
+};
+
+export default 검색결과;

--- a/src/app/search/components/인기검색어.tsx
+++ b/src/app/search/components/인기검색어.tsx
@@ -1,22 +1,26 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 import { useGetPopularFlower } from '@/api/flower-search';
 
 import Chip from './Chip';
 
 const 인기검색어 = () => {
   const popularFlower = useGetPopularFlower();
+  const router = useRouter();
 
   return (
-    <section className='flex flex-col p-[1.5rem]'>
-      <h3 className='text-[1.2rem] font-medium leading-[2.4rem] text-white'>
-        인기 검색어
-      </h3>
-      <p className='flex flex-wrap gap-12 text-[1.2rem] font-light leading-[2.4rem] text-green-100'>
+    <section className='flex flex-col p-24'>
+      <h3 className='text-12 font-medium leading-24 text-white'>인기 검색어</h3>
+      <p className='flex flex-wrap gap-12 text-12 font-light leading-24 text-green-100'>
         {popularFlower.data ? (
           popularFlower.data.map((flower, index) => (
             <Chip
               className='border-yellow text-yellow'
               key={index}
               label={`#${flower}`}
+              onClick={() => router.push(`/search?q=${flower}`)}
             />
           ))
         ) : (

--- a/src/app/search/components/인기검색어.tsx
+++ b/src/app/search/components/인기검색어.tsx
@@ -13,7 +13,11 @@ const 인기검색어 = () => {
       <p className='flex flex-wrap gap-12 text-[1.2rem] font-light leading-[2.4rem] text-green-100'>
         {popularFlower.data ? (
           popularFlower.data.map((flower, index) => (
-            <Chip key={index} label={`#${flower}`} />
+            <Chip
+              className='border-yellow text-yellow'
+              key={index}
+              label={`#${flower}`}
+            />
           ))
         ) : (
           <>인기검색어가 없습니다.</>

--- a/src/app/search/components/최근검색어.tsx
+++ b/src/app/search/components/최근검색어.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
 import { SvgIcon } from '@/common/components/svg-icon';
 
 import { useSearchHistory } from '../hooks';
@@ -7,9 +9,10 @@ import Chip from './Chip';
 
 const 최근검색어 = () => {
   const searchHistory = useSearchHistory();
+  const router = useRouter();
 
   return (
-    <section className='flex flex-col px-[1.5rem] pt-[1.5rem]'>
+    <section className='flex flex-col px-24 pt-24'>
       <h3 className='text-[1.2rem] font-medium leading-[2.4rem] text-white'>
         최근 검색어
       </h3>
@@ -23,24 +26,20 @@ const 최근검색어 = () => {
                 label={flower}
                 type='button'
                 leftComponent={
-                  <button
-                    type='button'
+                  <SvgIcon
+                    aria-labelledby='최근검색어 삭제'
+                    height='8'
+                    id='delete'
+                    role='img'
+                    stroke='#bcbcbc'
+                    width='8'
                     onClick={(e) => {
                       e.stopPropagation();
                       searchHistory.remove(flower);
                     }}
-                  >
-                    <SvgIcon
-                      aria-labelledby='최근검색어 삭제'
-                      height='8'
-                      id='delete'
-                      role='img'
-                      stroke='#bcbcbc'
-                      width='8'
-                    />
-                  </button>
+                  />
                 }
-                onClick={() => console.log('hih')}
+                onClick={() => router.push(`/search?q=${flower}`)}
               />
             ))}
       </p>

--- a/src/app/search/components/최근검색어.tsx
+++ b/src/app/search/components/최근검색어.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { SvgIcon } from '@/common/components/svg-icon';
+
 import { useSearchHistory } from '../hooks';
+import Chip from './Chip';
 
 const 최근검색어 = () => {
   const searchHistory = useSearchHistory();
@@ -10,12 +13,36 @@ const 최근검색어 = () => {
       <h3 className='text-[1.2rem] font-medium leading-[2.4rem] text-white'>
         최근 검색어
       </h3>
-      <p className='text-[1.2rem] font-light leading-[2.4rem] text-green-100'>
-        {searchHistory.history.length === 0 ? (
-          '최근 검색어가 없습니다.'
-        ) : (
-          <>최근 검색어</>
-        )}
+      <p className='flex flex-wrap gap-12 text-[1.2rem] font-light leading-[2.4rem] text-green-100'>
+        {searchHistory.history.length === 0
+          ? '최근 검색어가 없습니다.'
+          : searchHistory.history.map((flower, index) => (
+              <Chip
+                className='border-grey text-grey'
+                key={index}
+                label={flower}
+                type='button'
+                leftComponent={
+                  <button
+                    type='button'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      searchHistory.remove(flower);
+                    }}
+                  >
+                    <SvgIcon
+                      aria-labelledby='최근검색어 삭제'
+                      height='8'
+                      id='delete'
+                      role='img'
+                      stroke='#bcbcbc'
+                      width='8'
+                    />
+                  </button>
+                }
+                onClick={() => console.log('hih')}
+              />
+            ))}
       </p>
     </section>
   );

--- a/src/app/search/hooks/index.ts
+++ b/src/app/search/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useSearchHandle';
 export * from './useSearchHistory';

--- a/src/app/search/hooks/useSearchHandle.ts
+++ b/src/app/search/hooks/useSearchHandle.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect } from 'react';
+
+import { useInputState } from '@/common/hooks';
+
+import { useSearchHistory } from './useSearchHistory';
+
+export const useSearchHandle = () => {
+  const [value, setValue, handleChange] = useInputState('');
+  const searchHistory = useSearchHistory();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const query = searchParams.get('q') ?? value;
+
+  useEffect(() => {
+    setValue(query);
+  }, [setValue, query]);
+
+  const handleSearch = useCallback(
+    (newValue: string) => {
+      router.push(`/search?q=${newValue}`);
+      searchHistory.add(newValue);
+    },
+    [router, searchHistory]
+  );
+
+  return {
+    value,
+    setValue,
+    handleSearch,
+    handleChange,
+  } as const;
+};

--- a/src/app/search/hooks/useSearchHistory.ts
+++ b/src/app/search/hooks/useSearchHistory.ts
@@ -5,23 +5,20 @@ import { useCallback } from 'react';
 import { useLocalStorage } from '@/common/hooks';
 
 const LIMIT = 10;
-export const HISTORY_KEY = 'blossom-flower-search-history';
+const HISTORY_KEY = 'blossom-flower-search-history';
 
 export const useSearchHistory = () => {
-  const [history, setHistory] = useLocalStorage<string[]>(
-    'blossom-flower-search-history',
-    []
-  );
+  const [history, setHistory] = useLocalStorage<string[]>(HISTORY_KEY, []);
   const add = useCallback(
     (keyword: string) => {
       if (!keyword || !keyword.trim()) return;
 
       setHistory((prevHistory) => {
-        const prevHistorySet = new Set(prevHistory);
-        if (prevHistorySet.has(keyword)) {
-          prevHistorySet.delete(keyword);
-          prevHistorySet.add(keyword);
-          return Array.from(prevHistorySet.values());
+        const clone = new Set(prevHistory);
+        if (clone.has(keyword)) {
+          clone.delete(keyword);
+          clone.add(keyword);
+          return Array.from(clone.values());
         }
 
         if (prevHistory.length < LIMIT) return prevHistory.concat(keyword);
@@ -31,5 +28,16 @@ export const useSearchHistory = () => {
     [setHistory]
   );
 
-  return { history, add } as const;
+  const remove = useCallback(
+    (keyword: string) => {
+      setHistory((prevHistory) => {
+        const clone = new Set(prevHistory);
+        clone.delete(keyword);
+        return Array.from(clone.values());
+      });
+    },
+    [setHistory]
+  );
+
+  return { history, add, remove } as const;
 };

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,14 +1,29 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { ReactNode } from 'react';
+
 import { Header } from './components';
 
-export default function RedirectLayout({
+export default function SearchLayout({
   children,
+  main,
+  result,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
+  main: ReactNode;
+  result: ReactNode;
 }) {
+  const searchParams = useSearchParams();
+  const isResultPage = !!searchParams.get('q');
+
   return (
-    <section className='flex min-h-screen flex-col'>
-      <Header />
-      {children}
-    </section>
+    <>
+      <section className='flex h-full min-h-screen flex-col'>
+        <Header />
+        {children}
+        {isResultPage ? result : main}
+      </section>
+    </>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,22 +1,11 @@
 'use client';
 
-import { Suspense } from '@suspensive/react';
-
-import { SearchForm, 인기검색어, 최근검색어 } from './components';
+import { SearchForm } from './components';
 
 export default function SearchPage() {
   return (
     <>
       <SearchForm />
-
-      <Suspense.CSROnly>
-        <최근검색어 />
-      </Suspense.CSROnly>
-
-      <Suspense>
-        <인기검색어 />
-      </Suspense>
     </>
   );
 }
-

--- a/src/common/components/input/Input.tsx
+++ b/src/common/components/input/Input.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ComponentProps, ReactNode } from 'react';
+import { ComponentProps, ForwardedRef, forwardRef, ReactNode } from 'react';
 
 interface InputProps extends ComponentProps<'input'> {
   leftComponent?: ReactNode;
@@ -7,19 +7,24 @@ interface InputProps extends ComponentProps<'input'> {
   wrapperClassName?: string;
 }
 
-const Input = ({
-  leftComponent,
-  rightComponent,
-  className = '',
-  wrapperClassName = '',
-  ...inputProps
-}: InputProps) => {
+const Input = forwardRef(function Input(
+  props: InputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
+  const {
+    leftComponent,
+    rightComponent,
+    className = '',
+    wrapperClassName = '',
+    ...inputProps
+  } = props;
   return (
     <div className={`flex items-center gap-10 ${wrapperClassName}`}>
       <div>{leftComponent}</div>
-      <input {...inputProps} className={`flex-1 ${className}`} />
+      <input {...inputProps} className={`flex-1 ${className}`} ref={ref} />
       <div>{rightComponent}</div>
     </div>
   );
-};
+});
+
 export default Input;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
-/** @type {import('tailwindcss').Config} */
 const PX0_300 = { ...Array.from(Array(301)).map((_, i) => `${i / 10}rem`) };
 const PX0_50 = { ...Array.from(Array(51)).map((_, i) => `${i / 10}rem`) };
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -26,10 +26,15 @@ module.exports = {
           400: '#333A29',
         },
         yellow: '#FFCE00',
-        pink: '#FFCBF1',
+        pink: { 100: '#FFCBF1', 200: '#976489' },
         blue: '#7A7EA4',
       },
+      lineHeight: PX0_50,
       fontSize: {
+        ...PX0_50,
+        /**
+         * @deprecated
+         */
         '24-bold-24': [
           '2.4rem',
           { lineHeight: '24px', letterSpacing: '0em', fontWeight: '700' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,25 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.22.5":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
+"@emotion/is-prop-valid@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
+  integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -124,6 +143,36 @@
     strict-event-emitter "^0.2.4"
     web-encoding "^1.1.5"
 
+"@mui/base@^5.0.0-beta.6":
+  version "5.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.6.tgz#c4537231619f4642ebda714c2cfd0e598aa9f511"
+  integrity sha512-jcHy6HwOX7KzRhRtL8nvIvUlxvLx2Fl6NMRCyUSQSvMTyfou9kndekz0H4HJaXvG1Y4WEifk23RYedOlrD1kEQ==
+  dependencies:
+    "@babel/runtime" "^7.22.5"
+    "@emotion/is-prop-valid" "^1.2.1"
+    "@mui/types" "^7.2.4"
+    "@mui/utils" "^5.13.7"
+    "@popperjs/core" "^2.11.8"
+    clsx "^1.2.1"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
+"@mui/types@^7.2.4":
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.4.tgz#b6fade19323b754c5c6de679a38f068fd50b9328"
+  integrity sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==
+
+"@mui/utils@^5.13.7":
+  version "5.13.7"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.13.7.tgz#7e6a8336e05eb2642667a5c02eb605351e27ec20"
+  integrity sha512-/3BLptG/q0u36eYED7Nhf4fKXmcKb6LjjT7ZMwhZIZSdSxVqDqSTmATW3a56n3KEPQUXCU9TpxAfCBQhs6brVA==
+  dependencies:
+    "@babel/runtime" "^7.22.5"
+    "@types/prop-types" "^15.7.5"
+    "@types/react-is" "^18.2.1"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
 "@next/env@13.4.1":
   version "13.4.1"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.1.tgz#57322da2630b6bb6d7204577b0a18f6f9324db0c"
@@ -219,6 +268,11 @@
     picocolors "^1.0.0"
     tslib "^2.5.0"
 
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@rushstack/eslint-patch@^1.1.3":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
@@ -312,7 +366,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.2.tgz#8fd63447e3f99aba6c3168fd2ec4580d5b97886f"
   integrity sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.5":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -321,6 +375,13 @@
   version "18.2.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.4.tgz#13f25bfbf4e404d26f62ac6e406591451acba9e0"
   integrity sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-is@^18.2.1":
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-18.2.1.tgz#61d01c2a6fc089a53520c0b66996d458fdc46863"
+  integrity sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==
   dependencies:
     "@types/react" "*"
 
@@ -2790,6 +2851,11 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
close #24 

## 작업내용

- `@mui/base` 의존성 설치 -> [`useAutoComplete`](https://mui.com/base-ui/react-autocomplete/) 사용해서 검색 자동완성 상태 관리 위임
- 폰트 관련 스타일 변경
  - `text-24-normal-24` 컨벤션은 읽기 힘들고 한번에 무슨 의미인지 알기 어렵다고 판단
  - 특히 작은 서비스를 만드는데 위와 같은 컨벤션을 가져가고 디자이너와 소통하는 것은 소모적이라 판단했음
  - 그냥 tailwindcss의 아토믹한 className 을 적극 활용하고자 함
  - `line-height`, `font-size` className을 각각 `1-50px` 미리 생성(`tailwind.config.js`)
```ts
// as-is
<div className='text-24-normal-24'>...</div>

// to-be
<div className='text-24 leading-24 font-normal'>...</div>
```

- 꽃 검색 결과 유무에 따라 select 함수 반환값 다르게 변경(`useGetFlowerSearch.ts`)
  - `data`를 사용하는 쪽에서 검색 결과 유무를 쉽게 알도록 타입스크립트 타입 설계 고려
  - `useQuery` `select` 옵션에서 검색 결과 유무 판단
  - 아래 `type` 필드를 통해 데이터 유무를 판단하고 타입 안정성을 챙길 수 있도록 고려
```ts
const flowerSearch = useGetFlowerSearch();
if(flowerSearch.data.type === 'empty') {
  flowerSearch.data; // { type: 'empty', flowerTags: [], flowers: [], contentSummaryInfos: [] }
  // flowerTags, flowers, contentSummaryInfos 모두 비어있을 때
}
flowerSearch.data; // { type: 'exist', flowerTags: [ ... ], flowers: [ ... ], contentSummaryInfos: [ ... ] }
```

- [nextjs 13 parallele route](https://nextjs.org/docs/app/building-your-application/routing/parallel-routes) 사용해서 검색 메인 페이지와 검색 결과 페이지 라우팅 로직 구현